### PR TITLE
Customise Firefox path (in case of Snap) + use RunScriptAction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ venv.bak/
 
 # IDEs
 .idea
+.vscode/

--- a/history.py
+++ b/history.py
@@ -5,12 +5,12 @@ import configparser
 import os
 
 class FirefoxHistory():
-    def __init__(self):
+    def __init__(self, firefox_path: str):
         #   Results number
         self.limit = None
 
         #   Set history location
-        history_location = self.searchPlaces()
+        history_location = self.searchPlaces(firefox_path)
 
         #   Temporary  file
         #   Using FF63 the DB was locked for exclusive use of FF
@@ -22,9 +22,11 @@ class FirefoxHistory():
         #   External functions
         self.conn.create_function('hostname',1,self.__getHostname)
 
-    def searchPlaces(self):
+    def searchPlaces(self, firefox_path: str):
         #   Firefox folder path
-        firefox_path = os.path.join(os.environ['HOME'], '.mozilla/firefox/')
+        firefox_path = os.path.expanduser(firefox_path)
+        if not firefox_path.endswith("/"):
+            firefox_path += "/"
         #   Firefox profiles configuration file path
         conf_path = os.path.join(firefox_path,'profiles.ini')
         #   Profile config parse

--- a/main.py
+++ b/main.py
@@ -10,15 +10,22 @@ class FirefoxHistoryExtension(Extension):
     def __init__(self):
         super(FirefoxHistoryExtension, self).__init__()
         #   Firefox History Getter
-        self.fh = FirefoxHistory()
+        #   Delayed initialisation, need to get path from preferences
+        self.fh = None
         #   Ulauncher Events
         self.subscribe(KeywordQueryEvent,KeywordQueryEventListener())
         self.subscribe(SystemExitEvent,SystemExitEventListener())
         self.subscribe(PreferencesEvent,PreferencesEventListener())
         self.subscribe(PreferencesUpdateEvent,PreferencesUpdateEventListener())
 
+    def init_fh(self, firefox_path: str):
+        #   Initialise Firefox History Getter with path from preferences
+        if self.fh is None:
+            self.fh = FirefoxHistory(firefox_path)
+
 class PreferencesEventListener(EventListener):
     def on_event(self,event,extension):
+        extension.init_fh(event.preferences['path'])
         #   Aggregate Results
         #extension.fh.aggregate = event.preferences['aggregate']
         #   Results Order
@@ -32,6 +39,7 @@ class PreferencesEventListener(EventListener):
         
 class PreferencesUpdateEventListener(EventListener):
     def on_event(self,event,extension):
+        extension.init_fh(event.preferences['path'])
         #   Results Order
         #if event.id == 'order':
         #    extension.fh.order = event.new_value
@@ -47,10 +55,12 @@ class PreferencesUpdateEventListener(EventListener):
 
 class SystemExitEventListener(EventListener):
     def on_event(self,event,extension):
-        extension.fh.close()
+        if extension.fh is not None:
+            extension.fh.close()
 
 class KeywordQueryEventListener(EventListener):
     def on_event(self, event, extension):
+        extension.init_fh(event.preferences['path'])
         query  = event.get_argument()
         #   Blank Query
         if query == None:

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ from ulauncher.api.client.EventListener import EventListener
 from ulauncher.api.shared.event import KeywordQueryEvent, SystemExitEvent,PreferencesUpdateEvent, PreferencesEvent
 from ulauncher.api.shared.item.ExtensionResultItem import ExtensionResultItem
 from ulauncher.api.shared.action.RenderResultListAction import RenderResultListAction
-from ulauncher.api.shared.action.OpenUrlAction import OpenUrlAction
+from ulauncher.api.shared.action.RunScriptAction import RunScriptAction
 from history import FirefoxHistory
 
 class FirefoxHistoryExtension(Extension):
@@ -95,7 +95,7 @@ class KeywordQueryEventListener(EventListener):
             items.append(ExtensionResultItem(icon='images/icon.png',
                                             name=title,
                                             description=url,
-                                            on_enter=OpenUrlAction(url)))
+                                            on_enter=RunScriptAction(f"xdg-open {url}")))
 
         return RenderResultListAction(items)
 

--- a/main.py
+++ b/main.py
@@ -60,7 +60,7 @@ class SystemExitEventListener(EventListener):
 
 class KeywordQueryEventListener(EventListener):
     def on_event(self, event, extension):
-        extension.init_fh(event.preferences['path'])
+        extension.init_fh(extension.preferences['path'])
         query  = event.get_argument()
         #   Blank Query
         if query == None:

--- a/manifest.json
+++ b/manifest.json
@@ -19,6 +19,12 @@
         "type": "input",
         "name": "Results number",
         "default_value": "5"
+      },
+      {
+        "id": "path",
+        "type": "input",
+        "name": "Path to Firefox (requires restart)",
+        "default_value": "~/.mozilla/firefox/"
       }
     ]
   }


### PR DESCRIPTION
There are a number of forks that add Snap support by changing the path to Firefox, so I have added it as one of the preferences for the extension. I have also switched the action from OpenUrlAction to RunScriptAction with `xdg-open`, as OpenUrlAction does not hide uLauncher from view if Firefox starts closed.